### PR TITLE
fix: Replace broken server installer download URL

### DIFF
--- a/images/bf2hub-pb-mm-bf2cc/assets/build/assets.txt
+++ b/images/bf2hub-pb-mm-bf2cc/assets/build/assets.txt
@@ -1,4 +1,4 @@
-ftp://ftp.bf-games.net/server-files/bf2/bf2-linuxded-1.5.3153.0-installer.tgz
+https://www.bf-games.net/downloads/mirror/2956 bf2-linuxded-1.5.3153.0-installer.tgz
 https://www.bf2hub.com/downloads/BF2Hub-Unranked-Linux-R3.tar.gz
 https://static.nihlen.net/bf2/server/ModManager-v2.2c.zip
 https://download.mono-project.com/archive/1.1.12.1/linux-installer/0/mono-1.1.12.1_0-installer.bin

--- a/images/bf2hub-pb-mm-bf2cc/assets/build/build.sh
+++ b/images/bf2hub-pb-mm-bf2cc/assets/build/build.sh
@@ -18,7 +18,14 @@ apt-get -y update
 apt-get -y install wget expect unzip libglib2.0-0:i386
 
 # Download missing assets
-wget -nc -q --show-progress --progress=bar:force:noscroll -i assets.txt
+while IFS=" " read url filename
+do
+    args=(-nc -q --show-progress --progress=bar:force:noscroll)
+    if [ -n "$filename" ]; then
+        args+=(-O "$filename")
+    fi
+    wget "${args[@]}" "$url"
+done < assets.txt
 
 # Verify checksums
 if ! sha512sum -w -c assets.sha512; then

--- a/images/bf2hub-pb-mm-webadmin/assets/build/assets.txt
+++ b/images/bf2hub-pb-mm-webadmin/assets/build/assets.txt
@@ -1,3 +1,3 @@
-ftp://ftp.bf-games.net/server-files/bf2/bf2-linuxded-1.5.3153.0-installer.tgz
+https://www.bf-games.net/downloads/mirror/2956 bf2-linuxded-1.5.3153.0-installer.tgz
 https://www.bf2hub.com/downloads/BF2Hub-Unranked-Linux-R3.tar.gz
 https://static.nihlen.net/bf2/server/ModManager-v2.2c.zip

--- a/images/bf2hub-pb-mm-webadmin/assets/build/build.sh
+++ b/images/bf2hub-pb-mm-webadmin/assets/build/build.sh
@@ -15,7 +15,14 @@ apt-get -y update
 apt-get -y install wget expect unzip
 
 # Download missing assets
-wget -nc -q --show-progress --progress=bar:force:noscroll -i assets.txt
+while IFS=" " read url filename
+do
+    args=(-nc -q --show-progress --progress=bar:force:noscroll)
+    if [ -n "$filename" ]; then
+        args+=(-O "$filename")
+    fi
+    wget "${args[@]}" "$url"
+done < assets.txt
 
 # Verify checksums
 if ! sha512sum -w -c assets.sha512; then

--- a/images/bf2hub-pb-mm/assets/build/assets.txt
+++ b/images/bf2hub-pb-mm/assets/build/assets.txt
@@ -1,3 +1,3 @@
-ftp://ftp.bf-games.net/server-files/bf2/bf2-linuxded-1.5.3153.0-installer.tgz
+https://www.bf-games.net/downloads/mirror/2956 bf2-linuxded-1.5.3153.0-installer.tgz
 https://www.bf2hub.com/downloads/BF2Hub-Unranked-Linux-R3.tar.gz
 https://static.nihlen.net/bf2/server/ModManager-v2.2c.zip

--- a/images/bf2hub-pb-mm/assets/build/build.sh
+++ b/images/bf2hub-pb-mm/assets/build/build.sh
@@ -15,7 +15,14 @@ apt-get -y update
 apt-get -y install wget expect unzip
 
 # Download missing assets
-wget -nc -q --show-progress --progress=bar:force:noscroll -i assets.txt
+while IFS=" " read url filename
+do
+    args=(-nc -q --show-progress --progress=bar:force:noscroll)
+    if [ -n "$filename" ]; then
+        args+=(-O "$filename")
+    fi
+    wget "${args[@]}" "$url"
+done < assets.txt
 
 # Verify checksums
 if ! sha512sum -w -c assets.sha512; then

--- a/images/default/assets/build/assets.txt
+++ b/images/default/assets/build/assets.txt
@@ -1,1 +1,1 @@
-ftp://ftp.bf-games.net/server-files/bf2/bf2-linuxded-1.5.3153.0-installer.tgz
+https://www.bf-games.net/downloads/mirror/2956 bf2-linuxded-1.5.3153.0-installer.tgz

--- a/images/default/assets/build/build.sh
+++ b/images/default/assets/build/build.sh
@@ -13,7 +13,14 @@ apt-get -y update
 apt-get -y install wget expect
 
 # Download missing assets
-wget -nc -q --show-progress --progress=bar:force:noscroll -i assets.txt
+while IFS=" " read url filename
+do
+    args=(-nc -q --show-progress --progress=bar:force:noscroll)
+    if [ -n "$filename" ]; then
+        args+=(-O "$filename")
+    fi
+    wget "${args[@]}" "$url"
+done < assets.txt
 
 # Verify checksums
 if ! sha512sum -w -c assets.sha512; then


### PR DESCRIPTION
Looks like bf-games.net deprecated their FTP server or at least the direct access.

Needed to refactor the wget download a bit to be able to provide an alternate filename.