### PR TITLE
fix: Lock debian base image version to bullseye

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # bf2-docker
 
-Dockerized Battlefield 2 server based on [insanity54/bf42-dock](https://github.com/insanity54/bf42-dock). The base image is `debian:stretch-slim` and was tested on Linux containers in Windows 10 WSL2 and Debian 11. Uses multi-stage builds to keep the image sizes down.
+Dockerized Battlefield 2 server based on [insanity54/bf42-dock](https://github.com/insanity54/bf42-dock). The base image is `debian:bullseye-slim` and was tested on Linux containers in Windows 10 WSL2 and Debian 11. Uses multi-stage builds to keep the image sizes down.
 
 ## Prerequisites
 

--- a/images/bf2hub-pb-mm-bf2cc/Dockerfile
+++ b/images/bf2hub-pb-mm-bf2cc/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM debian:stable-slim AS build
+FROM debian:bullseye-slim AS build
 
 # Add assets to image
 WORKDIR /home/bf2/tmp
@@ -9,7 +9,7 @@ COPY ./assets/build ./
 RUN bash -x ./build.sh
 
 # Runtime stage
-FROM debian:stable-slim AS runtime
+FROM debian:bullseye-slim AS runtime
 WORKDIR /home/bf2/tmp
 LABEL maintainer=nihlen
 

--- a/images/bf2hub-pb-mm-webadmin/Dockerfile
+++ b/images/bf2hub-pb-mm-webadmin/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM debian:stable-slim AS build
+FROM debian:bullseye-slim AS build
 
 # Add assets to image
 WORKDIR /home/bf2/tmp
@@ -9,7 +9,7 @@ COPY ./assets/build ./
 RUN bash -x ./build.sh
 
 # Runtime stage
-FROM debian:stable-slim AS runtime
+FROM debian:bullseye-slim AS runtime
 WORKDIR /home/bf2/tmp
 LABEL maintainer=nihlen
 

--- a/images/bf2hub-pb-mm/Dockerfile
+++ b/images/bf2hub-pb-mm/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM debian:stable-slim AS build
+FROM debian:bullseye-slim AS build
 
 # Add assets to image
 WORKDIR /home/bf2/tmp
@@ -9,7 +9,7 @@ COPY ./assets/build ./
 RUN bash -x ./build.sh
 
 # Runtime stage
-FROM debian:stable-slim AS runtime
+FROM debian:bullseye-slim AS runtime
 WORKDIR /home/bf2/tmp
 LABEL maintainer=nihlen
 

--- a/images/default/Dockerfile
+++ b/images/default/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM debian:stable-slim AS build
+FROM debian:bullseye-slim AS build
 
 # Add assets to image
 WORKDIR /home/bf2/tmp
@@ -9,7 +9,7 @@ COPY ./assets/build ./
 RUN bash -x ./build.sh
 
 # Runtime stage
-FROM debian:stable-slim AS runtime
+FROM debian:bullseye-slim AS runtime
 WORKDIR /home/bf2/tmp
 LABEL maintainer=nihlen
 


### PR DESCRIPTION
Python 2 was removed from Debian Bookworm, which is the current `stable` release. Because of this, the image build currently fails saying that `python` has no installation candidate (which is part of the installed apt packages).

https://github.com/nihlen/bf2-docker/blob/711d8a98ebd0b175d7ff2efe7f40b5d0d529cc80/images/bf2hub-pb-mm/assets/runtime/setup.sh#L9-L18

Since there is no easy way of installing Python 2 on Bookworm (that I could find), the easiest fix is just going back to Bullseye (previous stable) for now.