### PR TITLE
fix: replace php7.0 with php7.4

### DIFF
--- a/images/bf2hub-pb-mm-webadmin/assets/runtime/nginx/default
+++ b/images/bf2hub-pb-mm-webadmin/assets/runtime/nginx/default
@@ -28,6 +28,6 @@ server {
     location ~ \.php$ {	
         alias /volume/www/;
         include snippets/fastcgi-php.conf;
-        fastcgi_pass unix:/var/run/php/php7.0-fpm.sock;
+        fastcgi_pass unix:/var/run/php/php7.4-fpm.sock;
     }
 }

--- a/images/bf2hub-pb-mm-webadmin/assets/runtime/run.sh
+++ b/images/bf2hub-pb-mm-webadmin/assets/runtime/run.sh
@@ -73,7 +73,7 @@ fi
 
 # Start nginx and php
 service nginx start
-service php7.0-fpm start
+service php7.4-fpm start
 
 # Start Battlefield 2 server as the bf2 user
 echo "Starting Battlefield 2 server..."

--- a/images/bf2hub-pb-mm-webadmin/assets/runtime/setup.sh
+++ b/images/bf2hub-pb-mm-webadmin/assets/runtime/setup.sh
@@ -9,10 +9,10 @@ TMP='/home/bf2/tmp'
 # Get required packages and create our user
 # libncurses5 = run bf2
 # python = rotate_demo.py
-# nginx + php7.0-fpm = host demos and bf2tool.php logs
+# nginx + php7.4-fpm = host demos and bf2tool.php logs
 apt -y update
 apt-get -y update
-apt-get -y install libncurses5 python nginx php7.0-fpm
+apt-get -y install libncurses5 python nginx php7.4-fpm
 apt-get clean
 rm -rf /var/lib/apt/lists/*
 useradd --create-home --shell /bin/bash bf2


### PR DESCRIPTION
Tried to build the `bf2hub-pb-mm-webadmin` image earlier, noticed that installing `php7.0-fpm` failed. Turns out PHP has been upgraded to 7.4 on bullseye, see https://packages.debian.org/bullseye/php-fpm.